### PR TITLE
Redirect invalid users

### DIFF
--- a/RubyonRails/app/helpers/application_helper.rb
+++ b/RubyonRails/app/helpers/application_helper.rb
@@ -1,4 +1,12 @@
 module ApplicationHelper
+    def flash_message(flash_type)
+        case flash_type
+        when 'notice' then 'success'
+        when 'alert'  then 'danger'
+        else flash_type.to_s
+        end
+    end
+
     def active_class(path)
         if request.path == path
             return 'active'

--- a/RubyonRails/app/models/key.rb
+++ b/RubyonRails/app/models/key.rb
@@ -4,6 +4,7 @@
 #
 #  id              :bigint           not null, primary key
 #  activation_code :string
+#  email           :string
 #  expiration      :datetime
 #  license_type    :integer
 #  used            :boolean

--- a/RubyonRails/app/models/user.rb
+++ b/RubyonRails/app/models/user.rb
@@ -90,5 +90,10 @@ class User < ApplicationRecord
     # Be aware this might not be unique. You will need to add validations or create more sophisticated logic.
     self.email.split('@').first
   end
+
+  public
+  def license_key
+    Key.find_by(email: email)
+  end
 end
 

--- a/RubyonRails/app/services/fetch_keys.rb
+++ b/RubyonRails/app/services/fetch_keys.rb
@@ -8,18 +8,33 @@ class FetchKeys
   base_uri 'api.dichoticsinc.com/api'
 
   def self.call
-    response = get("/license", query: { apiKey: '[CHANGE API KEY WHEN RUNNING]' })
-    if response.success?
-      response.parsed_response.each do |data|
-        create_key(data) if data['expiration'] && Time.parse(data['expiration']) > Time.now
-        
-      end
-    else
-      Rails.logger.error("FetchKeys: Error fetching data - #{response.message}")
-    end
+    fetch_keys
+    fetch_customers
   end
 
   private
+
+  def self.fetch_keys
+    response = get("/license", query: { apiKey: 'ears_lobo_audia_dichotic_capstone_winter23' })
+    if response.success?
+      response.parsed_response.each do |data|
+        create_key(data) if data['expiration'] && Time.parse(data['expiration']) > Time.now
+      end
+    else
+      Rails.logger.error("FetchKeys: Error fetching license data - #{response.message}")
+    end
+  end
+
+  def self.fetch_customers
+    response = get("/customer", query: { apiKey: 'ears_lobo_audia_dichotic_capstone_winter23' })
+    if response.success?
+      response.parsed_response.each do |data|
+        update_key_email(data)
+      end
+    else
+      Rails.logger.error("FetchKeys: Error fetching customer data - #{response.message}")
+    end
+  end
 
   def self.create_key(data)
     key = Key.find_or_initialize_by(license_id: data['licenseID'])
@@ -32,6 +47,10 @@ class FetchKeys
       subscription_id: data['subscriptiontID']
     )
     key.save if key.new_record? || key.changed?
-    puts "This license expires: #{data['expiration']}"
-    end
   end
+
+  def self.update_key_email(customer_data)
+    key = Key.find_by(customer_id: customer_data['customerID'])
+    key.update(email: customer_data['email']) if key
+  end
+end

--- a/RubyonRails/app/views/layouts/application.html.erb
+++ b/RubyonRails/app/views/layouts/application.html.erb
@@ -81,6 +81,20 @@
   </div>
 </nav>
 
+<% flash.each do |key, messages| %>
+  <% if messages.respond_to?(:each) %>
+    <% messages.each do |message| %>
+      <div class="alert alert-<%= flash_message(key) %> fade show" role="alert">
+        <%= message %>
+      </div>
+    <% end %>
+  <% else %>
+    <div class="alert alert-<%= flash_message(key) %> fade show" role="alert">
+      <%= messages %>
+    </div>
+  <% end %>
+<% end %>
+
 
 <%# all code for the calibration feature (inside modal made here) %>
 <div class="modal fade content-justify-center" id="myModal">

--- a/RubyonRails/db/migrate/20231203165706_add_email_to_keys.rb
+++ b/RubyonRails/db/migrate/20231203165706_add_email_to_keys.rb
@@ -1,0 +1,5 @@
+class AddEmailToKeys < ActiveRecord::Migration[6.1]
+  def change
+    add_column :keys, :email, :string
+  end
+end

--- a/RubyonRails/db/schema.rb
+++ b/RubyonRails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_12_01_021419) do
+ActiveRecord::Schema.define(version: 2023_12_03_165706) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -173,6 +173,7 @@ ActiveRecord::Schema.define(version: 2023_12_01_021419) do
     t.integer "product_id"
     t.integer "customer_id"
     t.integer "subscription_id"
+    t.string "email"
   end
 
   create_table "rddt_tests", force: :cascade do |t|

--- a/RubyonRails/db/seeds.rb
+++ b/RubyonRails/db/seeds.rb
@@ -27,7 +27,7 @@ keybruh = Key.create!(
   product_id: 1,
   customer_id: 1,
   subscription_id: 1,
-  expiration: Time.zone.now - 1.year, # Set expiration to 1 year from the current time
+  expiration: Time.zone.now + 1.year, # Set expiration to 1 year from the current time
   email: "global@gmail.com"
 )
 

--- a/RubyonRails/db/seeds.rb
+++ b/RubyonRails/db/seeds.rb
@@ -16,7 +16,8 @@ keybruh = Key.create!(
   product_id: 1,
   customer_id: 1,
   subscription_id: 1,
-  expiration: Time.zone.now + 1.year # Set expiration to 1 year from the current time
+  expiration: Time.zone.now + 1.year, # Set expiration to 1 year from the current time
+  email: "local@gmail.com"
 )
 
 keybruh = Key.create!(
@@ -26,7 +27,8 @@ keybruh = Key.create!(
   product_id: 1,
   customer_id: 1,
   subscription_id: 1,
-  expiration: Time.zone.now + 1.year # Set expiration to 1 year from the current time
+  expiration: Time.zone.now - 1.year, # Set expiration to 1 year from the current time
+  email: "global@gmail.com"
 )
 
 tenants = []

--- a/RubyonRails/test/fixtures/keys.yml
+++ b/RubyonRails/test/fixtures/keys.yml
@@ -4,6 +4,7 @@
 #
 #  id              :bigint           not null, primary key
 #  activation_code :string
+#  email           :string
 #  expiration      :datetime
 #  license_type    :integer
 #  used            :boolean

--- a/RubyonRails/test/models/key_test.rb
+++ b/RubyonRails/test/models/key_test.rb
@@ -4,6 +4,7 @@
 #
 #  id              :bigint           not null, primary key
 #  activation_code :string
+#  email           :string
 #  expiration      :datetime
 #  license_type    :integer
 #  used            :boolean


### PR DESCRIPTION
Added onto user sign-on validation:

- If the user's key is expired, redirect to login screen--do not let them log-in. And flash a message.

- Implemented custom flashing `flash_message`, that can be used globally throughout the app.

- In seeds, added associated email to key records.

- In users model, added func to lookup and match email from the keys model.